### PR TITLE
fix import path of intersection-observer dependency in sentinel

### DIFF
--- a/src/Sentinel.js
+++ b/src/Sentinel.js
@@ -1,5 +1,5 @@
 import React, { Component } from 'react';
-import { IntersectionObserver as Observer } from '@researchgate/react-intersection-observer/lib/js/IntersectionObserver';
+import Observer from '@researchgate/react-intersection-observer';
 import PropTypes from 'prop-types';
 import { computeRootMargin } from './utils';
 


### PR DESCRIPTION
## Description and Motivation
There seems to be a runtime error due to importing the `IntersectionObserver` component incorrectly. This leads to the `List` component hitting a "component is undefined" error in the browser.

Here's a link to a codesandbox demonstrating the error:
https://codesandbox.io/s/kind-bhaskara-4eznk?file=/src/App.js

## How has this been tested?
* I built, linked, and bundled a local copy of the project into a client app.
* I ran the local test suite and storybook components server.

#### Note:
It seems like the test suite mocks the IntersectionObserver component dependency, so that may effect its passing results.


## Type of change
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
- [x] I have read the [CONTRIBUTING](CONTRIBUTING.md) document
- [ ] I have added tests to cover my changes
- [x] All new and existing tests passed